### PR TITLE
Support custom hostnames for OpsGenie

### DIFF
--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -61,7 +61,6 @@ module AppOptics::Services
     end
 
     def post_it(hash, triggered_by_user_test)
-      url = "https://api.opsgenie.com/v1/json/appoptics"
       tags = settings[:tags].nil? ?  "" : settings[:tags].dup
       if triggered_by_user_test
         tags += tags.empty? ? "triggered_by_user_test" : ",triggered_by_user_test"
@@ -83,6 +82,11 @@ module AppOptics::Services
       else
         puts(msg)
       end
+    end
+
+    def url
+      hostname = settings[:hostname] || "api.opsgenie.com"
+      "https://#{hostname}/v1/json/appoptics"
     end
   end
 end

--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -85,7 +85,7 @@ module AppOptics::Services
     end
 
     def url
-      uri = URI.parse("htpts://api.opsgenie.com/v1/json/appoptics")
+      uri = URI.parse("https://api.opsgenie.com/v1/json/appoptics")
       if hostname = settings[:hostname]
         uri.host = hostname
       end

--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -85,12 +85,16 @@ module AppOptics::Services
     end
 
     def url
-      uri = URI.parse("https://api.opsgenie.com/v1/json/appoptics")
-      if hostname = settings[:hostname]
-        uri.host = hostname
-      end
+      begin
+        uri = URI.parse("https://api.opsgenie.com/v1/json/appoptics")
+        if hostname = settings[:hostname]
+          uri.host = hostname
+        end
 
-      uri.to_s
+        uri.to_s
+      rescue StandardError => e
+        raise_config_error(e.message)
+      end
     end
   end
 end

--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -85,8 +85,12 @@ module AppOptics::Services
     end
 
     def url
-      hostname = settings[:hostname] || "api.opsgenie.com"
-      "https://#{hostname}/v1/json/appoptics"
+      uri = URI.parse("htpts://api.opsgenie.com/v1/json/appoptics")
+      if hostname = settings[:hostname]
+        uri.host = hostname
+      end
+
+      uri.to_s
     end
   end
 end

--- a/test/opsgenie_test.rb
+++ b/test/opsgenie_test.rb
@@ -41,6 +41,21 @@ module AppOptics::Services
       svc.receive_alert
     end
 
+    def test_hostname_default
+      payload = new_alert_payload.dup
+      local_settings = @settings.dup
+      svc = service(:alert, local_settings, payload)
+      assert "https://api.opsgenie.com/v1/json/appptics", svc.url
+    end
+
+    def test_hostname_custom
+      payload = new_alert_payload.dup
+      local_settings = @settings.dup
+      local_settings[:hostname] = "api.eu.opsgenie.com"
+      svc = service(:alert, local_settings, payload)
+      assert "https://#{local_settings[:hostname]}/v1/json/appptics", svc.url
+    end
+
     def service(*args)
       super AppOptics::Services::Service::OpsGenie, *args
     end

--- a/test/opsgenie_test.rb
+++ b/test/opsgenie_test.rb
@@ -45,7 +45,7 @@ module AppOptics::Services
       payload = new_alert_payload.dup
       local_settings = @settings.dup
       svc = service(:alert, local_settings, payload)
-      assert "https://api.opsgenie.com/v1/json/appptics", svc.url
+      assert_equal "https://api.opsgenie.com/v1/json/appoptics", svc.url
     end
 
     def test_hostname_custom
@@ -53,7 +53,7 @@ module AppOptics::Services
       local_settings = @settings.dup
       local_settings[:hostname] = "api.eu.opsgenie.com"
       svc = service(:alert, local_settings, payload)
-      assert "https://#{local_settings[:hostname]}/v1/json/appptics", svc.url
+      assert_equal "https://#{local_settings[:hostname]}/v1/json/appoptics", svc.url
     end
 
     def service(*args)

--- a/test/opsgenie_test.rb
+++ b/test/opsgenie_test.rb
@@ -56,6 +56,14 @@ module AppOptics::Services
       assert_equal "https://#{local_settings[:hostname]}/v1/json/appoptics", svc.url
     end
 
+    def test_hostname_invald
+      payload = new_alert_payload.dup
+      local_settings = @settings.dup
+      local_settings[:hostname] = "lol"
+      svc = service(:alert, local_settings, payload)
+      assert_raises svc.url
+    end
+
     def service(*args)
       super AppOptics::Services::Service::OpsGenie, *args
     end


### PR DESCRIPTION
🎫 https://swicloud.atlassian.net/browse/AO-8564

The UI will expose a `hostname` field that users can use to override the hostname used for OpsGenie's API