### PR TITLE
Update README to show tag-based alert payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,24 +58,48 @@ Payload for a Triggered Alert
 -----------------------------
 
 A sample payload is available at
-[lib/appoptics-services/helpers/alert_helpers.rb] and listed below:
+[lib/appoptics-services/helpers/alert_helpers.rb](lib/appoptics-services/helpers/alert_helpers.rb) and listed below:
 
 ```
 "payload" : {
-  "alert" : {
-    "name" : "Alert name or nil",
-    "id" : 12345,
-  },
-  "incident_key": "<key that uniquely identifies this alert incident>",
-  "metric" : {
-     "name" : "Name of the metric that tripped alert",
-     "type" : "gauge" or "counter",
-  },
-  "measurements" : [{
-     "value" : 4.5 (value that caused exception),
-     "source" : "r3.acme.com" (source that caused exception
-                               or "unassigned")
-  }]
+{
+    "alert": {
+        "id": 7687374,
+        "name": "test.alert.name",
+        "runbook_url": "",
+        "version": 2,
+        "description": "The description of the alert"
+    },
+    "account": "youremail@yourdomain.com",
+    "trigger_time": 1539199059,
+    "incident_key": "appoptics-<alert id>-<incident id (internal)>",
+    "conditions": [
+        {
+            "id": 51960403,
+            "type": "above",
+            "threshold": 0,
+            "summary_function": "sum"
+        }
+    ],
+    "violations": {
+        "az=b": [
+            {
+                "metric": "AWS.ELB.RequestCount",
+                "value": 1181106,
+                "recorded_at": 1539198960,
+                "condition_violated": 51960403
+            }
+        ],
+        "az=c": [
+            {
+                "metric": "AWS.ELB.RequestCount",
+                "value": 1,
+                "recorded_at": 1539198840,
+                "condition_violated": 51960403
+            }
+        ]
+    },
+    "triggered_by_user_test": false
 }
 ```
 
@@ -84,17 +108,17 @@ Payload for a Cleared Alert
 
 ```
 "payload": {
-   "alert":{
-      "id":6268092,
-      "name":"a.test.name",
-      "runbook_url":"",
-      "version":2
-   },
-   "incident_key": "<key that uniquely identifies this alert incident>",
-   "account":"youremail@yourdomain.com",
-   "trigger_time":1457040045,
-   "clear":"normal"
-   }
+    "alert": {
+        "id": 7687374,
+        "name": "test.alert.name",
+        "runbook_url": "",
+        "version": 2,
+        "description": "The description of the alert"
+    },
+    "account": "youremail@yourdomain.com",
+    "trigger_time": 1539199160,
+    "clear": "normal",
+    "incident_key": "appoptics-<alert id>-<incident id (internal)>"
 }
 ```
 


### PR DESCRIPTION
This updates the example alert payload to use AppOptics' tags-based structure instead of the old Librato source-based structure.