### PR TITLE
Add number_with_delimiter helper to format numbers to be more readable

### DIFF
--- a/lib/appoptics-services/numbers.rb
+++ b/lib/appoptics-services/numbers.rb
@@ -1,3 +1,5 @@
+require 'active_support/all'
+
 module AppOptics
   module Services
     class Numbers
@@ -6,11 +8,11 @@ module AppOptics
         number_decimals = number_decimal_places(number)
 
         if !threshold_decimals || !number_decimals
-          return number
+          return number_with_delimiter(number)
         end
 
         if (number_decimals - tolerance) <= threshold_decimals
-          return number
+          return number_with_delimiter(number)
         end
 
         # here we have more decimals in the number than the threshold
@@ -18,7 +20,7 @@ module AppOptics
         # threshold: 3.14
 
         factor = (10**(threshold_decimals+tolerance)).to_f
-        (number * factor).truncate / factor
+        number_with_delimiter((number * factor).truncate / factor)
       end
 
       def self.number_decimal_places(number)
@@ -28,7 +30,27 @@ module AppOptics
         end
         segments[1].length
       end
+
+      # File actionpack/lib/action_view/helpers/number_helper.rb, line 199
+      def self.number_with_delimiter(number, options = {})
+        options.symbolize_keys!
+
+        begin
+          Float(number)
+        rescue ArgumentError, TypeError
+          if options[:raise]
+            raise InvalidNumberError, number
+          else
+            return number
+          end
+        end
+
+        options = options.reverse_merge({ delimiter: ',', separator: '.' })
+
+        parts = number.to_s.to_str.split('.')
+        parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
+        parts.join(options[:separator]).html_safe
+      end
     end
   end
 end
-

--- a/test/numbers_test.rb
+++ b/test/numbers_test.rb
@@ -8,16 +8,18 @@ class NumbersTest < Test::Unit::TestCase
   end
 
   def test_does_not_change
-    assert format(10, 10.53) == 10.53
-    assert format(10.53, 10.53) == 10.53
+    assert format(10, 10.53) == "10.53"
+    assert format(10.53, 10.53) == "10.53"
   end
 
   def test_changes
-    assert_equal 10.5312, format(10.53, 10.5312345)
-    assert_equal 10.53, format(10, 10.5312345)
-    assert_equal 0.53, format(0, 0.5312345)
-    assert_equal 0.5312, format(0.12, 0.5312345)
-    assert_equal 100, format(10, 100)
+    assert_equal "10.5312", format(10.53, 10.5312345)
+    assert_equal "10.53", format(10, 10.5312345)
+    assert_equal "0.53", format(0, 0.5312345)
+    assert_equal "0.5312", format(0.12, 0.5312345)
+    assert_equal "100", format(10, 100)
+    assert_equal "12,345,678", format(10, 12345678)
+    assert_equal "12,345,678.0", format(10, 12345678.0)
   end
 
 


### PR DESCRIPTION
When an Alert notification is sent it looks for example like this:
```
environment=production
metric `kafka.buzzard.delta` was above threshold 20000000 over 300 seconds with value 22469048 recorded at Tue, Apr  2 2019 at 02:45:00 UTC
```
If you look at the numbers it's really hard to figure out if 20000000 is 20,000,000 or 2,000,000 or 200,000,000. Added `number_with_delimiter` helper known from Rails to make numbers more readable.